### PR TITLE
(feat) adding typejuice

### DIFF
--- a/packages/ai-lab/README.md
+++ b/packages/ai-lab/README.md
@@ -1,0 +1,26 @@
+## Interface: ModelInfo
+
+### Properties
+
+- **`iouThreshold`**: **number** (optional)
+  The the allowed area for intersection over union (IOU) between the bounding box with other bounding boxes.
+- **`maxBoxes`**: **number**
+  The number of boxes to keep after applying NMS.
+- **`modelType`**: **undefined** | **undefined**
+  The model type, which identifies the output structure to expect.
+- **`nmsActive`**: **boolean** (optional)
+  The soft NMS Sigma that allows overlapping of strong object confidence.
+- **`threshold`**: **number** (optional)
+  The score threshold to identify if a value is returned.
+
+## Interface: VideoProps
+
+## Interface: ObjectDetectionUIProps
+
+### Properties
+
+- **`detectionResults`**: ****
+- **`height`**: **number**
+- **`modelInfo`**: **ModelInfo**
+- **`onDrawComplete`**: **** (optional)
+- **`width`**: **number**

--- a/packages/ai-lab/document.js
+++ b/packages/ai-lab/document.js
@@ -1,0 +1,12 @@
+const TypeJuice = require('typejuice');
+const fs = require('fs');
+
+const tj = new TypeJuice('./src/types.ts');
+
+const content = tj.toMarkdown();
+fs.writeFile('./README.md', content, (err) => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+});

--- a/packages/ai-lab/package.json
+++ b/packages/ai-lab/package.json
@@ -14,7 +14,8 @@
     "start": "tsdx watch --verbose --noClean",
     "build": "tsdx build",
     "lint": "tsdx lint",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "doc": "node document.js"
   },
   "author": "Gant Laborde",
   "license": "MIT",
@@ -27,6 +28,7 @@
     "babel-loader": "^8.2.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "typejuice": "^0.0.1",
     "typescript": "^4.4.3"
   },
   "dependencies": {

--- a/packages/ai-lab/src/types.ts
+++ b/packages/ai-lab/src/types.ts
@@ -3,10 +3,16 @@ import React from 'react';
 import { PerformanceProps } from './performance';
 
 export interface ModelInfo {
+  // The the allowed area for intersection over union (IOU)
+  // between the bounding box with other bounding boxes.
   iouThreshold?: number;
+  // The number of boxes to keep after applying NMS.
   maxBoxes: number;
+  // The model type, which identifies the output structure to expect.
   modelType: 'classification' | 'ssd';
+  // The soft NMS Sigma that allows overlapping of strong object confidence.
   nmsActive?: boolean;
+  // The score threshold to identify if a value is returned.
   threshold?: number;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,7 @@ importers:
       react: 17.0.2
       react-dom: ^17.0.2
       regenerator-runtime: ^0.13.7
+      typejuice: ^0.0.1
       typescript: ^4.4.3
     dependencies:
       '@tensorflow/tfjs': 2.6.0
@@ -155,6 +156,7 @@ importers:
       babel-loader: 8.2.3_@babel+core@7.15.8
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      typejuice: 0.0.1
       typescript: 4.4.3
 
   packages/ai-lab-native:
@@ -8624,6 +8626,7 @@ packages:
 
   /bindings/1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -11398,6 +11401,7 @@ packages:
 
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -15316,6 +15320,7 @@ packages:
 
   /nan/2.15.0:
     resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==}
+    requiresBuild: true
     dev: true
 
   /nanocolors/0.1.12:
@@ -19524,6 +19529,13 @@ packages:
 
   /typedarray/0.0.6:
     resolution: {integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=}
+    dev: true
+
+  /typejuice/0.0.1:
+    resolution: {integrity: sha512-3F/HMTx5lYrLSHmQBP6yDkCYTv9LR8HVTgSK3fm5Hnhd2ipBx6bStdXwue3JMPQ27ZfJS9HlLUWgpgC5VTX1XQ==}
+    dependencies:
+      typescript: 4.5.4
+      word-wrap: 1.2.3
     dev: true
 
   /typescript/3.9.10:


### PR DESCRIPTION
Now you can type `pnpm doc` in the `ai-lab` package and it will automatically generated a README.md based off of the `types.ts` file.  This is using an autodocumentation trick called "typejuice" which renders markdown from type files.

![image](https://user-images.githubusercontent.com/997157/147788242-02bc324d-25f3-49b4-bbe0-a23b8b39a9a7.png)


As the types file grows, this will be an easy way to document interfaces.