### PR TITLE
Fix canvas size and add content size control in storybook

### DIFF
--- a/examples/ai-lab-example/storybook/AILabImageClassification.stories.tsx
+++ b/examples/ai-lab-example/storybook/AILabImageClassification.stories.tsx
@@ -26,6 +26,10 @@ export default {
         description: 'Comma separated classification labels',
       },
     },
+    displaySize: {
+      options: ['content', 'max'],
+      control: { type: 'select' },
+    },
   },
 } as ComponentMeta<typeof AILabImage>;
 
@@ -102,6 +106,7 @@ const imageParamsStory: ComponentStory<typeof AILabImage> = (
         //@ts-ignore
         labels: args.labels.split(/,\s*/),
       }}
+      displaySize={args.displaySize}
     />
   );
 };
@@ -113,10 +118,18 @@ withImageAndCustomizedSettings.args = {
   perf: true,
   threshold: 0.4,
   labels: CLASSES.join(', '),
+  displaySize: 'content',
 };
 
 withImageAndCustomizedSettings.parameters = {
   controls: {
-    include: ['imageSource', 'maxResults', 'perf', 'threshold', 'labels'],
+    include: [
+      'imageSource',
+      'maxResults',
+      'perf',
+      'threshold',
+      'labels',
+      'displaySize',
+    ],
   },
 };

--- a/examples/ai-lab-example/storybook/AILabImageSSD.stories.tsx
+++ b/examples/ai-lab-example/storybook/AILabImageSSD.stories.tsx
@@ -36,6 +36,10 @@ export default {
         description: 'Comma separated classification labels',
       },
     },
+    displaySize: {
+      options: ['content', 'max'],
+      control: { type: 'select' },
+    },
   },
 } as ComponentMeta<typeof AILabImage>;
 
@@ -127,6 +131,7 @@ const imageParamsStory: ComponentStory<typeof AILabImage> = (
         labels: args.labels.split(/,\s*/),
       }}
       visual={args.visual}
+      displaySize={args.displaySize}
     />
   );
 };
@@ -142,6 +147,7 @@ withImageAndCustomizedSettings.args = {
   perf: true,
   threshold: 0.4,
   visual: true,
+  displaySize: 'content',
 };
 
 withImageAndCustomizedSettings.parameters = {
@@ -156,6 +162,7 @@ withImageAndCustomizedSettings.parameters = {
       'perf',
       'threshold',
       'visual',
+      'displaySize',
     ],
   },
 };

--- a/examples/ai-lab-example/storybook/AILabLocalVideoClassification.stories.tsx
+++ b/examples/ai-lab-example/storybook/AILabLocalVideoClassification.stories.tsx
@@ -27,6 +27,10 @@ export default {
         description: 'Comma separated classification labels',
       },
     },
+    displaySize: {
+      options: ['content', 'max'],
+      control: { type: 'select' },
+    },
   },
 } as ComponentMeta<typeof AILabLocalVideo>;
 
@@ -94,6 +98,7 @@ const localVideoParamsStory: ComponentStory<typeof AILabLocalVideo> = (
         //@ts-ignore
         labels: args.labels.split(/,\s*/),
       }}
+      displaySize={args.displaySize}
     />
   );
 };
@@ -110,10 +115,18 @@ withLocalVideoAndCustomizedSettings.args = {
   threshold: 0.4,
   videoSource:
     'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4',
+  displaySize: 'content',
 };
 
 withLocalVideoAndCustomizedSettings.parameters = {
   controls: {
-    include: ['labels', 'maxResults', 'perf', 'threshold', 'videoSource'],
+    include: [
+      'labels',
+      'maxResults',
+      'perf',
+      'threshold',
+      'videoSource',
+      'displaySize',
+    ],
   },
 };

--- a/examples/ai-lab-example/storybook/AILabLocalVideoSSD.stories.tsx
+++ b/examples/ai-lab-example/storybook/AILabLocalVideoSSD.stories.tsx
@@ -37,6 +37,10 @@ export default {
         description: 'Comma separated classification labels',
       },
     },
+    displaySize: {
+      options: ['content', 'max'],
+      control: { type: 'select' },
+    },
   },
 } as ComponentMeta<typeof AILabLocalVideo>;
 
@@ -118,6 +122,7 @@ const localVideoParamsStory: ComponentStory<typeof AILabLocalVideo> = (
         labels: args.labels.split(/,\s*/),
       }}
       visual={args.visual}
+      displaySize={args.displaySize}
     />
   );
 };
@@ -137,6 +142,7 @@ withLocalVideoAndCustomizedSettings.args = {
   visual: true,
   videoSource:
     'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4',
+  displaySize: 'content',
 };
 
 withLocalVideoAndCustomizedSettings.parameters = {
@@ -151,6 +157,7 @@ withLocalVideoAndCustomizedSettings.parameters = {
       'threshold',
       'visual',
       'videoSource',
+      'displaySize',
     ],
   },
 };

--- a/examples/ai-lab-example/storybook/AILabWebCamClassification.stories.tsx
+++ b/examples/ai-lab-example/storybook/AILabWebCamClassification.stories.tsx
@@ -22,6 +22,10 @@ export default {
         description: 'Comma separated classification labels',
       },
     },
+    displaySize: {
+      options: ['content', 'max'],
+      control: { type: 'select' },
+    },
   },
 } as ComponentMeta<typeof AILabWebCam>;
 
@@ -77,6 +81,7 @@ const webCamParamsStory: ComponentStory<typeof AILabWebCam> = (
         //@ts-ignore
         labels: args.labels.split(/,\s*/),
       }}
+      displaySize={args.displaySize}
     />
   );
 };
@@ -87,10 +92,11 @@ withWebCamAndCustomizedSettings.args = {
   perf: true,
   threshold: 0.4,
   labels: CLASSES.join(', '),
+  displaySize: 'content',
 };
 
 withWebCamAndCustomizedSettings.parameters = {
   controls: {
-    include: ['maxResults', 'perf', 'threshold', 'labels'],
+    include: ['maxResults', 'perf', 'threshold', 'labels', 'displaySize'],
   },
 };

--- a/examples/ai-lab-example/storybook/AILabWebCamSSD.stories.tsx
+++ b/examples/ai-lab-example/storybook/AILabWebCamSSD.stories.tsx
@@ -32,6 +32,10 @@ export default {
         description: 'Comma separated classification labels',
       },
     },
+    displaySize: {
+      options: ['content', 'max'],
+      control: { type: 'select' },
+    },
   },
 } as ComponentMeta<typeof AILabWebCam>;
 
@@ -100,6 +104,7 @@ const webCamParamsStory: ComponentStory<typeof AILabWebCam> = (
       labels: args.labels.split(/,\s*/),
     }}
     visual={args.visual}
+    displaySize={args.displaySize}
   />
 );
 
@@ -114,6 +119,7 @@ withWebCamAndCustomizedSettings.args = {
   perf: true,
   threshold: 0.4,
   visual: true,
+  displaySize: 'content',
 };
 
 withWebCamAndCustomizedSettings.parameters = {
@@ -128,6 +134,7 @@ withWebCamAndCustomizedSettings.parameters = {
       'perf',
       'threshold',
       'visual',
+      'displaySize',
     ],
   },
 };

--- a/packages/ai-lab/src/components/AILabImage/AILabImage.tsx
+++ b/packages/ai-lab/src/components/AILabImage/AILabImage.tsx
@@ -29,7 +29,8 @@ export const AILabImage = ({
   src,
   size = 224,
   visual,
-  ...props
+  displaySize,
+  style,
 }: ImageProps) => {
   const [isTFReady, setIsTFReady] = useState(false);
   const imgRef = useRef<HTMLImageElement>(null);
@@ -109,26 +110,33 @@ export const AILabImage = ({
   }, [modelConfig, results]);
 
   return (
-    <div style={{ position: 'relative' }}>
-      <img ref={imgRef} src={src} {...props} />
-      {visual && (
-        <ObjectDetectionUI
-          detectionResults={detectionResults}
-          height={imgRef.current?.height ?? 0}
-          modelConfig={{ ...defaultModelConfig, ...modelConfig }}
-          onDrawComplete={(durationMs) => {
-            if (!drawingTime) {
-              setDrawingTime(durationMs);
-            }
-          }}
-          width={imgRef.current?.width ?? 0}
+    <div style={style}>
+      <div style={{ position: 'relative' }}>
+        {perf && perfProps && (
+          <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0 }}>
+            <Performance {...perfProps} drawingTime={drawingTime} />
+          </div>
+        )}
+        <img
+          ref={imgRef}
+          src={src}
+          height={displaySize === 'max' ? '100%' : undefined}
+          width={displaySize === 'max' ? '100%' : undefined}
         />
-      )}
-      {perf && perfProps && (
-        <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0 }}>
-          <Performance {...perfProps} drawingTime={drawingTime} />
-        </div>
-      )}
+        {visual && (
+          <ObjectDetectionUI
+            detectionResults={detectionResults}
+            height={imgRef.current?.offsetHeight ?? 0}
+            modelConfig={{ ...defaultModelConfig, ...modelConfig }}
+            onDrawComplete={(durationMs) => {
+              if (!drawingTime) {
+                setDrawingTime(durationMs);
+              }
+            }}
+            width={imgRef.current?.offsetWidth ?? 0}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/ai-lab/src/components/AILabObjectDetectionUI.tsx
+++ b/packages/ai-lab/src/components/AILabObjectDetectionUI.tsx
@@ -76,10 +76,10 @@ export const AILabObjectDetectionUI = ({
   return (
     <div
       style={{
-        bottom: 0,
         left: 0,
         position: 'absolute',
-        right: 0,
+        width,
+        height,
         top: 0,
       }}
     >

--- a/packages/ai-lab/src/components/AILabVideo/AILabLocalVideo.tsx
+++ b/packages/ai-lab/src/components/AILabVideo/AILabLocalVideo.tsx
@@ -31,6 +31,8 @@ export const AILabLocalVideo = ({
   size = 224,
   src,
   visual,
+  displaySize,
+  style,
 }: VideoProps) => {
   const [isTFReady, setIsTFReady] = useState(false);
   const [perfProps, setPerfProps] = useState<PerformanceInfo>();
@@ -38,9 +40,6 @@ export const AILabLocalVideo = ({
   const videoRef = useRef<HTMLVideoElement>(null);
   const [detectionResults, setDetectionResults] = useState<any>({});
   const [results, setResults] = useState<Results>();
-
-  const maxWidth = window.innerWidth - 18; // subtract scrollbar
-  const maxHeight = window.innerHeight;
 
   async function tensorFlowIt(model: tf.GraphModel | tf.LayersModel) {
     // fix scan ahead processing issue
@@ -127,7 +126,7 @@ export const AILabLocalVideo = ({
   }, [modelConfig, results]);
 
   return (
-    <div>
+    <div style={style}>
       <div style={{ position: 'relative' }}>
         {perf && perfProps && !!drawingTime && (
           <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0 }}>
@@ -137,14 +136,14 @@ export const AILabLocalVideo = ({
         {visual && (
           <ObjectDetectionUI
             detectionResults={detectionResults}
-            height={videoRef.current?.height ?? 0}
+            height={videoRef.current?.offsetHeight ?? 0}
             modelConfig={{ ...defaultModelConfig, ...modelConfig }}
             onDrawComplete={(durationMs) => {
               if (!drawingTime) {
                 setDrawingTime(durationMs);
               }
             }}
-            width={videoRef.current?.width ?? 0}
+            width={videoRef.current?.offsetWidth ?? 0}
           />
         )}
         <video
@@ -152,8 +151,8 @@ export const AILabLocalVideo = ({
           id="video"
           src={src}
           ref={videoRef}
-          width={maxWidth}
-          height={maxHeight}
+          width={displaySize === 'max' ? '100%' : undefined}
+          height={displaySize === 'max' ? '100%' : undefined}
           controls
           onEnded={stopTFJS}
           onPlay={startInference}

--- a/packages/ai-lab/src/components/SimpleObjectDetectionUI.tsx
+++ b/packages/ai-lab/src/components/SimpleObjectDetectionUI.tsx
@@ -54,7 +54,7 @@ export const SimpleObjectDetectionUI = ({
   return (
     <canvas
       ref={canvasRef}
-      style={{ position: 'absolute', left: 0, right: 0, bottom: 0, top: 0 }}
+      style={{ position: 'absolute', left: 0, top: 0, height, width }}
     />
   );
 };

--- a/packages/ai-lab/src/lib/hooks.ts
+++ b/packages/ai-lab/src/lib/hooks.ts
@@ -1,0 +1,35 @@
+import React, { useState, useLayoutEffect } from 'react';
+
+function getSize(el?: HTMLElement | null) {
+  if (!el) {
+    return {};
+  }
+
+  return {
+    width: el.offsetWidth,
+    height: el.offsetHeight,
+  };
+}
+
+export function useComponentSize(
+  ref: React.MutableRefObject<HTMLElement | null>
+) {
+  const [componentSize, setComponentSize] = useState(getSize(ref.current));
+
+  function handleResize() {
+    if (ref && ref.current) {
+      setComponentSize(getSize(ref.current));
+    }
+  }
+
+  useLayoutEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return componentSize;
+}

--- a/packages/ai-lab/src/types.ts
+++ b/packages/ai-lab/src/types.ts
@@ -20,6 +20,7 @@ export type ImageProps = React.ImgHTMLAttributes<HTMLImageElement> &
     onInference?: (inferenceData: any) => void;
     size?: number;
     visual?: boolean;
+    displaySize?: 'content' | 'max';
   };
 
 export interface VideoProps
@@ -35,6 +36,7 @@ export interface VideoProps
   size?: number;
   src?: string;
   visual?: boolean;
+  displaySize?: 'content' | 'max';
 }
 
 export interface Detections {


### PR DESCRIPTION
### What's changed

Per issue #49 No.2, The boundary box drawing that happened outside of the content is fixed. And there is a display size control with `content` to show the original content size and `max`  to expand it.

### Photos / Videos / Gifs
![ezgif com-gif-maker](https://user-images.githubusercontent.com/53795920/150654780-84173ce8-cf1c-45f6-b006-cdcefd51d4d0.gif)
